### PR TITLE
Version 1.0.1

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,10 +11,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    branches:
-      - master
-      # - develop
+  release:
+    types: [released]
 
 jobs:
   deploy:
@@ -33,12 +31,6 @@ jobs:
         pip install build setuptools twine --user
     - name: Build package
       run: python -m build
-    # - name: Publish package 📦 to Test PyPI
-    #   if: ${{ !startsWith(github.ref, 'refs/tags') }}
-    #   uses: pypa/gh-action-pypi-publish@master
-    #   with:
-    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-    #     repository_url: https://test.pypi.org/legacy/
     - name: Publish package 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ on:
   push:
     branches:
       - master
-      - develop
+      # - develop
 
 jobs:
   deploy:
@@ -33,12 +33,12 @@ jobs:
         pip install build setuptools twine --user
     - name: Build package
       run: python -m build
-    - name: Publish package 📦 to Test PyPI
-      if: ${{ !startsWith(github.ref, 'refs/tags') }}
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
+    # - name: Publish package 📦 to Test PyPI
+    #   if: ${{ !startsWith(github.ref, 'refs/tags') }}
+    #   uses: pypa/gh-action-pypi-publish@master
+    #   with:
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository_url: https://test.pypi.org/legacy/
     - name: Publish package 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ The items listed here are only minor notes and are of low priority. So it may be
 
 ## [Upcoming Release][unreleased]
 
+Empty
+
+## [1.0.1] - 2021-07-02
+
+- **Added** - Japanese README
+- **Changed** - Move the checklog icon to the front.
 - **Fixed** - Fix [#4](https://github.com/ryul1206/multilingual-markdown/issues/4): ToC contents are broken when a header(#) has a link.
 
 ## [1.0.a2] - 2021-06-17
@@ -51,7 +57,8 @@ The items listed here are only minor notes and are of low priority. So it may be
 - **Added** - Initial python module. (`multilang_md,py`)
 - **Added** - Added french translation to README and example. [PR #1](https://github.com/ryul1206/multilingual-markdown/pull/1) by [**@bkg2018**](https://github.com/bkg2018)
 
-[unreleased]: https://github.com/ryul1206/multilingual-markdown/compare/v1.0.a2...develop
+[unreleased]: https://github.com/ryul1206/multilingual-markdown/compare/v1.0.1...develop
+[1.0.1]: https://github.com/ryul1206/multilingual-markdown/releases/tag/v1.0.1
 [1.0.a2]: https://github.com/ryul1206/multilingual-markdown/releases/tag/v1.0.a2
 [1.0.a1]: https://github.com/ryul1206/multilingual-markdown/releases/tag/v1.0.a1
 [0.2.0]: https://github.com/ryul1206/multilingual-markdown/releases/tag/v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 <!--
 알파벳 순서
 Added 새로운 기능
@@ -17,9 +15,15 @@ Fixed 버그 픽스
 Security 취약점이 있는 경우
 -->
 
-To do
+### Not Scheduled
+
+The items listed here are only minor notes and are of low priority. So it may be out of focus forever, but if you need anything, please [publish an issue](https://github.com/ryul1206/multilingual-markdown/issues).
 
 - Better emoji detection (https://stackoverflow.com/questions/43146528/how-to-extract-all-the-emojis-from-text)
+
+## [Upcoming Release][unreleased]
+
+- **Fixed** - Fix [#4](https://github.com/ryul1206/multilingual-markdown/issues/4): ToC contents are broken when a header(#) has a link.
 
 ## [1.0.a2] - 2021-06-17
 

--- a/README.base.md
+++ b/README.base.md
@@ -559,11 +559,11 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `mmg [OPTIONS] [FILENAMES]...`
   - Uninstall: `xargs rm -rf < temp.txt`
-- Windows (Not recommended)
+- Windows
   - Required packages: `pip3 install -r .\requirements_dev.txt --user`
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
-  - Uninstall (PowerShell): `Get-Content .\temp.txt | Remove-Item`
+  - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
 ### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
 

--- a/README.base.md
+++ b/README.base.md
@@ -565,7 +565,7 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
   - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
-### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
+### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)
 
 ### Contributors
 

--- a/README.base.md
+++ b/README.base.md
@@ -1,5 +1,5 @@
 <!---------------------------->
-<!-- multilingual suffix: en, fr, kr -->
+<!-- multilingual suffix: en, fr, kr, jp -->
 <!-- no suffix: en -->
 <!---------------------------->
 
@@ -14,7 +14,11 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 <!-- [kr] -->
 # 다국어 마크다운 생성기
 
-이 패키지는 다국어 콘텐츠를 관리하고, 단일 기본 파일로부터 i18n 마크 다운을 생성하는 명령 줄 인터페이스(CLI)를 제공합니다.
+이 패키지는 단일 기본 파일로부터 다국어 콘텐츠를 관리하고, i18n 마크 다운을 생성하는 명령 줄 인터페이스 (CLI)를 제공합니다.
+<!-- [jp] -->
+# 多言語マークダウンジェネレータ
+
+このパッケージは、単一のデフォルトのファイルから多言語コンテンツを管理してi18nマークダウンを生成するコマンドラインインタフェース（CLI）を提供しています。
 <!-- [common] -->
 
 [![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
@@ -22,10 +26,11 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ![GitHub](https://img.shields.io/github/license/ryul1206/multilingual-markdown.svg)
 [![CodeFactor](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/badge/master)](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/overview/master)
 
-🚀 **version 1.0-alpha.2** 🌏
+🚀 **version 1.0.1** 🌏
 [English](https://github.com/ryul1206/multilingual-markdown/blob/master/README.md),
 [Français](https://github.com/ryul1206/multilingual-markdown/blob/master/README.fr.md),
 [한국어](https://github.com/ryul1206/multilingual-markdown/blob/master/README.kr.md)
+[日本語](https://github.com/ryul1206/multilingual-markdown/blob/master/README.jp.md))
 
 ---
 
@@ -33,6 +38,8 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 **Table of Contents** ⚡
 <!-- [kr] -->
 **목차** ⚡
+<!-- [jp] -->
+**目次** ⚡
 <!-- [fr] -->
 **Table des matières** ⚡
 <!-- [common] -->
@@ -45,6 +52,8 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ## Aperçu 🔎
 <!-- [kr] -->
 ## 개요 🔎
+<!-- [jp] -->
+## 概要 🔎
 <!-- [common] -->
 
 <!-- [en] -->
@@ -53,6 +62,8 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ### Fonctionnement
 <!-- [kr] -->
 ### 작동 방식
+<!-- [jp] -->
+### 作動方式
 <!-- [common] -->
 ![how it works](how-it-works.png)
 
@@ -60,25 +71,38 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ### Features
 
 - Auto suffix to file name
-- No suffix option (for one main language)
-- UTF-8 encoding. So *maybe* this will support almost all languages. :) 🍷
+  - [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) are also available.
+  - Remove suffix option for one main language
+- UTF-8 encoding. So this *would* support almost all languages. :) 🍷
 - Auto table of contents
     - Table of contents level options
     - Table of contents emoji **on-off** options
 <!-- [kr] -->
-### 기능들
+### 기능
 
 - 파일 이름 뒤에 자동 접미사
-- 접미사 생략 옵션 (한 개 언어만 가능)
-- UTF-8 인코딩. 따라서 *아마도* 거의 모든 언어를 지원할겁니다. :) 🍷
+  - [IETF 언어 태그](https://ko.wikipedia.org/wiki/IETF_%EC%96%B8%EC%96%B4_%ED%83%9C%EA%B7%B8) 사용 가능
+  - 접미사 생략 옵션 (한 개 언어만 가능)
+- UTF-8 인코딩. 따라서 *아마* 거의 모든 언어를 지원합니다. :) 🍷
 - 자동 목차
     - 목차로 만들 제목수준 설정 가능
     - 목차에서 이모티콘 **표시/생략** 설정 가능
+<!-- [jp] -->
+### 技能
+
+- ファイル名の後に自動接尾辞
+  - [IETF言語タグ](https://ja.wikipedia.org/wiki/IETF%E8%A8%80%E8%AA%9E%E3%82%BF%E3%82%B0) 使用可能
+  - 接尾辞省略オプション(1ヶ国語のみ)
+- UTF-8エンコード。 ですので、*たぶん*ほぼすべての言語をサポートします。 :) 🍷
+- 自動目次
+    - 目次で作成するタイトルレベル設定可能
+    - 目次で絵文字を **"表示/省略"** 設定可能
 <!-- [fr] -->
 ### Fonctionnalités
 
 - Suffixe automatique des noms de fichier
-- Possibilité d'omettre le suffixe (pour la langue principale)
+  - [Étiquette d'identification de langues IETF](https://fr.wikipedia.org/wiki/%C3%89tiquette_d%27identification_de_langues_IETF) ​sont également disponibles
+  - Possibilité d'omettre le suffixe (pour la langue principale)
 - Encodage UTF-8. Cela *devrait* supporter presque toutes les langues. :) 🍷
 - Table des matières automatique
     - Niveaux de titres au choix
@@ -91,6 +115,8 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ## Installer
 <!-- [kr] -->
 ## 설치
+<!-- [jp] -->
+## 設置
 <!-- [common] -->
 
 ```sh
@@ -103,6 +129,8 @@ Now when you open a new terminal you can use the new command `mmg`.
 Maintenant, lorsque vous ouvrez un nouveau terminal, vous pouvez utiliser la nouvelle commande `mmg`.
 <!-- [kr] -->
 이제 새터미널을 열면 새로운 명령어 `mmg`를 사용할 수 있습니다.
+<!-- [jp] -->
+これで、新ターミナルを開けると新しいコマンド「mmg」が使えます。
 <!-- [common] -->
 
 ```sh
@@ -127,6 +155,8 @@ Options:
 ## Mises à jour
 <!-- [kr] -->
 ## 업데이트
+<!-- [jp] -->
+## アップデート
 <!-- [common] -->
 
 ```sh
@@ -139,6 +169,8 @@ pip3 install mmg --upgrade --user
 ## Désinstaller
 <!-- [kr] -->
 ## 제거
+<!-- [jp] -->
+## 削除
 <!-- [common] -->
 
 ```sh
@@ -151,20 +183,34 @@ pip3 uninstall mmg
 ## Mode d'emploi
 <!-- [kr] -->
 ## 사용법
+<!-- [jp] -->
+## 使用方法
 <!-- [common] -->
 
 <!-- [en] -->
+### (0) Make a Base Markdown File
+
 Make `{something}.base.md` files. See [README.base.md](README.base.md) and [example.base.md](example/example.base.md) for examples, and [Command Tags](#Command-Tags) for rules.
 
 **(Note) A wrong format of base-file will break generated style.**
 <!-- [fr] -->
+### (0) Créer un fichier de démarques de base
+
 Saisissez les fichiers multilingues avec une extension `.base.md`. Voir les exemples [README.base.md](README.base.md) et [example.base.md](example/example.base.md) et reportez-vous à [Marqueurs](#marqueurs) pour les règles.
 
 **(Remarque) Un format incorrect de fichier de base cassera le style généré.**
 <!-- [kr] -->
+### (0) 베이스 마크다운 파일 만들기
+
 `{파일이름}.base.md` 파일을 만듭니다. 예제는 [README.base.md](README.base.md) 와 [example.base.md](example/example.base.md) 를 참고하시고, 작성하는 규칙은 [명령어 태그](#명령어-태그)를 참고하십시오.
 
 **(경고) 베이스 파일 형식이 잘못되면 생성된 스타일이 깨집니다.**
+<!-- [jp] -->
+### （0）ベースマークダウンファイル作成
+
+`{ファイル名}.base.md`ファイルを作成します。例では、[README.base.md](README.base.md)と[example.base.md](example/example.base.md)を参照し、作成するルールは、[コマンドタグ](#コマンドタグ)を参照してください。
+
+**（警告）ベースのファイル形式が間違っている場合生成されたスタイルが壊れます。**
 <!-- [common] -->
 
 <!-- [en] -->
@@ -173,6 +219,8 @@ Saisissez les fichiers multilingues avec une extension `.base.md`. Voir les exem
 ### (1) Spécification du fichier cible
 <!-- [kr] -->
 ### (1) 파일 지정
+<!-- [jp] -->
+### （1）ファイルを指定
 <!-- [common] -->
 
 <!-- [en] -->
@@ -181,6 +229,8 @@ Enter the `*.base.md` files that you want to create in multiple languages as arg
 Entrez les fichiers `* .base.md` que vous souhaitez créer dans plusieurs langues comme arguments de la commande` mmg`.
 <!-- [kr] -->
 다국어로 생성하고 싶은 `*.base.md` 파일을 `mmg` 명령에 인자(arguments)로 넣어줍니다.
+<!-- [jp] -->
+多言語で作成したい`*.base.md`ファイルを`mmg`コマンド引数（arguments）で入れてくれます。
 <!-- [common] -->
 
 ```sh
@@ -193,6 +243,8 @@ Multiple arguments are separated by spaces.
 Les arguments multiples sont séparés par des espaces.
 <!-- [kr] -->
 여러 인자는 띄어쓰기로 구분합니다.
+<!-- [jp] -->
+複数の引数は、間隔で区切ります。
 <!-- [common] -->
 
 ```sh
@@ -205,6 +257,8 @@ mmg Foo.base.md Bar.base.md Baz.base.md
 ### (2) Option Récursive
 <!-- [kr] -->
 ### (2) 재귀 옵션 (recursive option)
+<!-- [jp] -->
+### （2）再帰オプション（recursive option）
 <!-- [common] -->
 
 <!-- [en] -->
@@ -219,6 +273,8 @@ Vous ne pouvez pas encore spécifier un dossier comme argument.
 현재 디렉토리와 하위 디렉토리에 있는 모든 베이스 파일을 변환하고 싶다면 `--recursive` 또는 `-r` 옵션을 사용하세요.
 recursive option은 명령어가 입력된 위치를 기준으로 모든 하위 폴더를 탐색합니다.
 아직은 인자로 폴더를 지정할 수 없습니다.
+<!-- [jp] -->
+現在のディレクトリおよびサブディレクトリにあるすべてのデータベースファイルを変換したい場合は`--recursive`、または`-r`オプションを使用します。recursive optionはコマンドが入力された位置を基準にすべてのサブフォルダを移動します。まだ引数としてフォルダを指定することができません。
 <!-- [common] -->
 
 ```sh
@@ -240,6 +296,10 @@ Lorsque votre fichier peut avoir un problème.
 
 문제가 있는 것으로 의심되는 경우.
 (정상은 녹색으로, 비정상은 빨간색으로 표시됩니다.)
+<!-- [jp] -->
+###（3）データベースファイルの検証
+
+問題があると疑われる場合。（通常は緑色で、異常は赤で表示されます。）
 <!-- [common] -->
 
 ```sh
@@ -265,6 +325,8 @@ When your files are ok.
 Lorsque vos fichiers sont ok.
 <!-- [kr] -->
 문제점이 없다면
+<!-- [jp] -->
+問題がなければ、
 <!-- [common] -->
 
 ```sh
@@ -285,6 +347,8 @@ Do you want to convert these files? [y/N]
 ### (4) Plus d'explications
 <!-- [kr] -->
 ### (4) 부연 설명
+<!-- [jp] -->
+### （4）より多くの説明
 <!-- [common] -->
 
 <!-- [en] -->
@@ -302,6 +366,11 @@ Do you want to convert these files? [y/N]
     - 기본일 때: `{파일이름}.en.md`, `{파일이름}.kr.md`, `{파일이름}.es.md`, ...
     - `en`에 접미사 생략 옵션일 때: `{파일이름}.md`, `{파일이름}.kr.md`, `{파일이름}.es.md`, ...
 - 이 생성기는 자동생성된 파일을 매번 덮어쓰기 때문에, `{파일이름}.base.md` 파일을 수정하더라도 매번 지울 필요가 없습니다. 그저 방금 전 2단계를 다시 실행하면 됩니다.
+<!-- [jp] -->
+- 各フォルダの同じ場所で`{ファイル名}.{接尾辞}.md`になったファイルを見ることができます。例えば：
+  - 基本のとき：`{ファイル名}.en.md`、`{ファイル名}.kr.md`、`{ファイル名}.es.md`、...
+  - `en`サフィックス省略オプションのとき：`{ファイル名}.md`、`{ファイル名}.kr.md`、`{ファイル名}.es.md`、...
+- このジェネレータは、自動生成されたファイルを毎回上書きされるため、`{ファイル名}.base.md`ファイルを変更しても、毎回消去する必要がありません。ただ先ほどステップ2を再度実行します。
 <!-- [common] -->
 
 <!-- [en] -->
@@ -310,6 +379,8 @@ Do you want to convert these files? [y/N]
 ## 명령어 태그
 <!-- [fr] -->
 ## Marqueurs
+<!-- [jp] -->
+## コマンドタグ
 <!-- [common] -->
 
 <!-- [en] -->
@@ -324,6 +395,10 @@ Headers must be declared before the body begins.
 ### Titres
 
 Les titres doivent être déclarés avant le corps de texte.
+<!-- [jp] -->
+### ヘッダ
+
+ヘッダは、必ず本体を開始する前に宣言する必要があります。
 <!-- [common] -->
 
 <!-- [en] -->
@@ -338,6 +413,10 @@ Les titres doivent être déclarés avant le corps de texte.
 1. **Déclaration des suffixes**
 
     Déclarez les langues que vous souhaitez utiliser. Dans l'exemple suivant, on déclare les mots-clés `en`, `kr` et `fr` et quelque autres. Ces mots-clés seront utilisés comme suffixes des noms de fichier et comme marqueurs dans les fichiers `base.md`.
+<!-- [jp] -->
+1. **サフィックス宣言**
+
+    使用する言語を宣言します。次の例では、enとkrをキーワードで宣言しました。このキーワードは、接尾辞として使用されます。
 <!-- [common] -->
 
     ```markdown
@@ -356,6 +435,10 @@ Les titres doivent être déclarés avant le corps de texte.
 1. **Suffixe invisible** (facultatif)
 
     L'option `no suffix` évite l'ajout de l'un des suffixes lors de la création des fichiers. Ainsi, appliquer `no suffix`à la langue `en` génèrera *`fichier`*`.md` au lieu de *`fichier`*`.en.md`. Cela est utile par exemple pour le `README` obligatoire dans  **GitHub** qui n sera pas reconnu s'il a un suffixe (par exemple `README.en.md`).
+<!-- [jp] -->
+1. **サフィックスを非表示**（必須ではない）
+
+    `no suffix`オプションは、ファイルを作成するときにサフィックスがつくのを防ぐことができます。言い換えればno suffixをenに設定すると、`ファイル名.en.md`ではなく、`ファイル名.md`が生成されます。**GitHub**からメイン`README`はサフィックスが付く認識にならないので、この機能が便利です。
 <!-- [common] -->
 
     ```markdown
@@ -368,6 +451,8 @@ Les titres doivent être déclarés avant le corps de texte.
 ### 뱃지 달기
 <!-- [fr] -->
 ### Badges
+<!-- [jp] -->
+### バッジ付け
 <!-- [common] -->
 
 [![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
@@ -392,6 +477,10 @@ Everything that the parser reads after the tag below is recognized as the main t
 ### Corps de texte
 
 Tout ce qui suit le marqueur est interprété comme corps principal de texte, donc vous devez placer les titres avant le texte.
+<!-- [jp] -->
+### 本文
+
+パーサが下のタグ立ち寄る読む瞬間から、その後に読むすべてはメインテキストとして認識します。（だからヘッダをメインの前に書かなければならいます。）
 <!-- [common] -->
 
 <!-- [en] -->
@@ -400,6 +489,8 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
 1. **키워드**
 <!-- [fr] -->
 1. **Mots-clés**
+<!-- [jp] -->
+1. **キーワード**
 <!-- [common] -->
 <!-- [en] -->
     1. Language Classification
@@ -413,6 +504,10 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
     1. Classification de langue
 
         Les marqueurs qui distinguent les languages sont écrits sous la forme `<!-- [marqueur] -->`. Si un marqueur est reconnu, il sera retenu jusqu'à ce qu'un autre soit reconnu.
+<!-- [jp] -->
+    1. 言語分類
+
+        言語を区別するタグは、`<!-- [キーワード] -->`同じ形で作成します。一つのキーワードが認識されると、他のキーワードが表示されるまで、そのキーワードとして認識されます。
 <!-- [common] -->
 
         ```markdown
@@ -433,6 +528,10 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
     1. 공통 영역
 
         생성될 모든 파일에 공통적으로 들어갈 내용은 `common` 키워드를 사용하여 작성하면 됩니다.
+<!-- [jp] -->
+    1. 共通領域
+
+        生成されるすべてのファイルに共通に入る内容は`common`、キーワードを使用して作成します。
 <!-- [fr] -->
     1. Section commune
 
@@ -455,6 +554,10 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
     1. Section ignorée
 
         Vous pouvez exclure des parties du texte telles que les blocs de commentaires ou les TODO avec le mot-clé `ignore`.
+<!-- [jp] -->
+    1. 無視される領域
+
+        コメントやTODOなどのいくつかの項目は、生成されるファイルに含ましたくない場合があります。そのような場合`ignore`、キーワードを使用します。
 <!-- [common] -->
 
         ```markdown
@@ -479,6 +582,12 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
     Les marqueurs sont automatiquement placés dans la table des matières par le générateur. Le niveau de titre auquel commence la table des matières peut être indiqué avec l'option `level`. Le niveau le plus haut est 1, ce qui correspond aux titres Markdown `# titre` et aux tags HTML `<H1>`.
 
     **(Remarque) Si vous sautez le niveau de titre de la démarque marquée avec `#`, une erreur se produira. En d'autres termes, le sous-titre de `##` doit être `###`.**
+<!-- [jp] -->
+1. **目次**
+
+    次のタグは、ジェネレータによって本文に自動的に置き換えられます。目次のレベルは、`level`部分を介してすることができます。最大のタイトル（`# 題目`）はhtmlで`<h1>`あるため`level 1`です。
+
+    **（注意）`#`に表示するマークダウンの見出しレベルをスキップエラーが発生します。つまり、`##`サブタイトルは`###`でなければします。**
 <!-- [common] -->
 
     ```markdown
@@ -515,6 +624,16 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
         - Vous pouvez écrire les marqueurs de la table des matières plusieurs fois dans le document et spécifier différentes options `level` à chaque fois.
         - **ATTENTION💥**: si vous ommettez `level` le script ignorera la commande.
         - **ATTENTION💥**: le marqueur `table of contents` change automatiquement le marqueur de section pour `common` donc les commandes de la table des matières concernent toutes les langues, et vous devez réindiquer un marqueur de langue par la suite.
+<!-- [jp] -->
+    1. **`level`オプション**
+        - `level`を表記する方法は、合計4つあります。お客様のニーズに応じて、数字は変えたらされます。
+            - `level=2`：2レベルの見出しのみ目次にします。
+            - `level=2~`：2〜9レベルの見出しのみ目次にします。
+            - `level=~4`：1〜4レベルの見出しのみ目次にします。
+            - `level=2~4`：2〜4レベルの見出しのみ目次にします。
+        - 1つの記事で`table of contents`タグは何度も書くことができ、毎回異なる`level`オプションを与えることもできます。
+        - **注意💥**：もし`level`を省略すると、パーサが認識しない。
+        - **注意💥**：目次タグは、自動的に現在のキーワードを`common`変更します。だから目次タグも暗黙的に`common`に属します。
 <!-- [en] -->
     2. **`no-emoji` option**
         - You may want to subtract emoji from the table of contents while inserting emoji in a section title.😱 If you are in this situation, apply the `no-emoji` option as shown below.😎
@@ -524,6 +643,9 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
 <!-- [fr] -->
     2. **Option `no-emoji`**
         - Vous pouvez souhaiter mettre un emoji dans un titre sans qu'il apparaisse dans la table des matières.😱 dans ce cas, utilisez l'option `no-emoji` comme indiqué ci-dessous 😎
+<!-- [jp] -->
+    2. **`no-emoji`オプション**
+        - セクションのタイトルには、絵文字を入れながら、目次では、絵文字を消したいときがあります。😱 もしあなたがこのような状況であれば、以下のように`no-emoji`オプションを適用します。😎
 <!-- [common] -->
 
         ```markdown
@@ -536,14 +658,18 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
 ## Contribution
 <!-- [kr] -->
 ## 기여
+<!-- [jp] -->
+## 貢献
 <!-- [common] -->
 
 <!-- [en] -->
-I would appreciate anything you send. (e.g. translations, simple improvements, bug reports, and so on.) Especially I would be very grateful if you could translate this `README.md` document into your language not listed here and give it to me.
+I would appreciate anything you send. (e.g. translations, simple improvements, bug reports, and so on.)
 <!-- [fr] -->
-Toute contribution sera grandement appréciée. (ex: traductions, améliorations, signalements de bugs etc.) Je serai particulièrement reconnaissant si vous pouviez traduire ce `README.md` dans votre langue et me l'envoyer.
+Toute contribution sera grandement appréciée. (ex: traductions, améliorations, signalements de bugs etc.)
 <!-- [kr] -->
-번역, 단순한 개선, 버그 제보 등 어떠한 것이라도 소중히 받습니다. 특히 이 `README.md` 문서를 여기에 없는 다른 언어로 번역해주신다면 매우 감사드립니다.
+번역, 단순한 개선, 버그 제보 등 어떠한 것이라도 소중히 받습니다.
+<!-- [jp] -->
+翻訳、単純な改善、バグ情報提供などいかなるものでも大切に受けます。
 <!-- [common] -->
 
 <!-- [en] -->
@@ -552,6 +678,8 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
 ### Comment construire localement pour le développement
 <!-- [kr] -->
 ### 개발을 위해 local로 빌드하는 방법
+<!-- [jp] -->
+### 開発のためのlocalに構築する方法
 <!-- [common] -->
 
 - Linux and MacOS
@@ -575,6 +703,8 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
 > 기여자 명단은 영어로만 제공됩니다.
 <!-- [fr] -->
 > La liste des contributeurs est en Anglais seulement.
+<!-- [jp] -->
+> 貢献リストは英語のみで提供されます。
 <!-- [common] -->
 
 - [@bkg2018 (Francis Piérot)](https://github.com/bkg2018): Added french translation to README and example. [PR #1](https://github.com/ryul1206/multilingual-markdown/pull/1)

--- a/README.fr.md
+++ b/README.fr.md
@@ -23,17 +23,17 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 1. [Mises à jour](#Mises-à-jour)
 1. [Désinstaller](#Désinstaller)
 1. [Mode d'emploi](#Mode-demploi)
-    1. [(1) Spécification du fichier cible](#1-Spécification-du-fichier-cible)
-    1. [(2) Option Récursive](#2-Option-Récursive)
-    1. [(3) Validation du Fichier de Base](#3-Validation-du-Fichier-de-Base)
-    1. [(4) Plus d'explications](#4-Plus-dexplications)
+    1. [(1) Spécification du fichier cible](#(1)-Spécification-du-fichier-cible)
+    1. [(2) Option Récursive](#(2)-Option-Récursive)
+    1. [(3) Validation du Fichier de Base](#(3)-Validation-du-Fichier-de-Base)
+    1. [(4) Plus d'explications](#(4)-Plus-dexplications)
 1. [Marqueurs](#Marqueurs)
     1. [Titres](#Titres)
     1. [Badges](#Badges)
     1. [Corps de texte](#Corps-de-texte)
 1. [Contribution](#Contribution)
     1. [Comment construire localement pour le développement](#Comment-construire-localement-pour-le-développement)
-    1. [[Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)](#Changeloghttpsgithubcomryul1206multilingual-markdownblobmasterCHANGELOGmd)
+    1. [Changelog](#Changelog)
     1. [Contributors](#Contributors)
 
 ## Aperçu 🔎
@@ -265,11 +265,11 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `mmg [OPTIONS] [FILENAMES]...`
   - Uninstall: `xargs rm -rf < temp.txt`
-- Windows (Not recommended)
+- Windows
   - Required packages: `pip3 install -r .\requirements_dev.txt --user`
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
-  - Uninstall (PowerShell): `Get-Content .\temp.txt | Remove-Item`
+  - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
 ### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -271,7 +271,7 @@ Toute contribution sera grandement appréciée. (ex: traductions, améliorations
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
   - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
-### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
+### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)
 
 ### Contributors
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -7,10 +7,11 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ![GitHub](https://img.shields.io/github/license/ryul1206/multilingual-markdown.svg)
 [![CodeFactor](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/badge/master)](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/overview/master)
 
-🚀 **version 1.0-alpha.2** 🌏
+🚀 **version 1.0.1** 🌏
 [English](https://github.com/ryul1206/multilingual-markdown/blob/master/README.md),
 [Français](https://github.com/ryul1206/multilingual-markdown/blob/master/README.fr.md),
 [한국어](https://github.com/ryul1206/multilingual-markdown/blob/master/README.kr.md)
+[日本語](https://github.com/ryul1206/multilingual-markdown/blob/master/README.jp.md))
 
 ---
 
@@ -23,10 +24,11 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 1. [Mises à jour](#Mises-à-jour)
 1. [Désinstaller](#Désinstaller)
 1. [Mode d'emploi](#Mode-demploi)
-    1. [(1) Spécification du fichier cible](#(1)-Spécification-du-fichier-cible)
-    1. [(2) Option Récursive](#(2)-Option-Récursive)
-    1. [(3) Validation du Fichier de Base](#(3)-Validation-du-Fichier-de-Base)
-    1. [(4) Plus d'explications](#(4)-Plus-dexplications)
+    1. [(0) Créer un fichier de démarques de base](#0-Créer-un-fichier-de-démarques-de-base)
+    1. [(1) Spécification du fichier cible](#1-Spécification-du-fichier-cible)
+    1. [(2) Option Récursive](#2-Option-Récursive)
+    1. [(3) Validation du Fichier de Base](#3-Validation-du-Fichier-de-Base)
+    1. [(4) Plus d'explications](#4-Plus-dexplications)
 1. [Marqueurs](#Marqueurs)
     1. [Titres](#Titres)
     1. [Badges](#Badges)
@@ -44,7 +46,8 @@ Ce package fournit une interface de ligne de commande pour gérer les contenus m
 ### Fonctionnalités
 
 - Suffixe automatique des noms de fichier
-- Possibilité d'omettre le suffixe (pour la langue principale)
+  - [Étiquette d'identification de langues IETF](https://fr.wikipedia.org/wiki/%C3%89tiquette_d%27identification_de_langues_IETF) ​sont également disponibles
+  - Possibilité d'omettre le suffixe (pour la langue principale)
 - Encodage UTF-8. Cela *devrait* supporter presque toutes les langues. :) 🍷
 - Table des matières automatique
     - Niveaux de titres au choix
@@ -87,6 +90,8 @@ pip3 uninstall mmg
 ```
 
 ## Mode d'emploi
+
+### (0) Créer un fichier de démarques de base
 
 Saisissez les fichiers multilingues avec une extension `.base.md`. Voir les exemples [README.base.md](README.base.md) et [example.base.md](example/example.base.md) et reportez-vous à [Marqueurs](#marqueurs) pour les règles.
 
@@ -256,7 +261,7 @@ Tout ce qui suit le marqueur est interprété comme corps principal de texte, do
 
 ## Contribution
 
-Toute contribution sera grandement appréciée. (ex: traductions, améliorations, signalements de bugs etc.) Je serai particulièrement reconnaissant si vous pouviez traduire ce `README.md` dans votre langue et me l'envoyer.
+Toute contribution sera grandement appréciée. (ex: traductions, améliorations, signalements de bugs etc.)
 
 ### Comment construire localement pour le développement
 

--- a/README.jp.md
+++ b/README.jp.md
@@ -1,0 +1,282 @@
+# 多言語マークダウンジェネレータ
+
+このパッケージは、単一のデフォルトのファイルから多言語コンテンツを管理してi18nマークダウンを生成するコマンドラインインタフェース（CLI）を提供しています。
+
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
+![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/ryul1206/multilingual-markdown.svg)
+![GitHub](https://img.shields.io/github/license/ryul1206/multilingual-markdown.svg)
+[![CodeFactor](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/badge/master)](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/overview/master)
+
+🚀 **version 1.0.1** 🌏
+[English](https://github.com/ryul1206/multilingual-markdown/blob/master/README.md),
+[Français](https://github.com/ryul1206/multilingual-markdown/blob/master/README.fr.md),
+[한국어](https://github.com/ryul1206/multilingual-markdown/blob/master/README.kr.md)
+[日本語](https://github.com/ryul1206/multilingual-markdown/blob/master/README.jp.md))
+
+---
+
+**目次** ⚡
+
+1. [概要 ](#概要-)
+    1. [作動方式](#作動方式)
+    1. [技能](#技能)
+1. [設置](#設置)
+1. [アップデート](#アップデート)
+1. [削除](#削除)
+1. [使用方法](#使用方法)
+    1. [（0）ベースマークダウンファイル作成](#（0）ベースマークダウンファイル作成)
+    1. [（1）ファイルを指定](#（1）ファイルを指定)
+    1. [（2）再帰オプション（recursive option）](#（2）再帰オプション（recursive-option）)
+    1. [（4）より多くの説明](#（4）より多くの説明)
+1. [コマンドタグ](#コマンドタグ)
+    1. [ヘッダ](#ヘッダ)
+    1. [バッジ付け](#バッジ付け)
+    1. [本文](#本文)
+1. [貢献](#貢献)
+    1. [開発のためのlocalに構築する方法](#開発のためのlocalに構築する方法)
+    1. [Changelog](#Changelog)
+    1. [Contributors](#Contributors)
+
+## 概要 🔎
+
+### 作動方式
+![how it works](how-it-works.png)
+
+### 技能
+
+- ファイル名の後に自動接尾辞
+  - [IETF言語タグ](https://ja.wikipedia.org/wiki/IETF%E8%A8%80%E8%AA%9E%E3%82%BF%E3%82%B0) 使用可能
+  - 接尾辞省略オプション(1ヶ国語のみ)
+- UTF-8エンコード。 ですので、*たぶん*ほぼすべての言語をサポートします。 :) 🍷
+- 自動目次
+    - 目次で作成するタイトルレベル設定可能
+    - 目次で絵文字を **"表示/省略"** 設定可能
+
+## 設置
+
+```sh
+pip3 install mmg --user
+```
+
+これで、新ターミナルを開けると新しいコマンド「mmg」が使えます。
+
+```sh
+$ mmg --help
+mmg [OPTIONS] [FILENAMES]...
+
+Options:
+  --version                 Show the current version.
+  -r, --recursive           This recursive option searches all subfolders
+                            based on current directory and converts all base
+                            files.
+  -y, --yes                 Confirm the action without prompting
+  -c, --check / -s, --skip  Check the number of language tags of each file
+                            (defualt: --check)
+  -v, --verbose             For example, -v:1, -vv:2, -vvv:3  [x>=0]
+  --help                    Show this message and exit.
+```
+
+## アップデート
+
+```sh
+pip3 install mmg --upgrade --user
+```
+
+## 削除
+
+```sh
+pip3 uninstall mmg
+```
+
+## 使用方法
+
+### （0）ベースマークダウンファイル作成
+
+`{ファイル名}.base.md`ファイルを作成します。例では、[README.base.md](README.base.md)と[example.base.md](example/example.base.md)を参照し、作成するルールは、[コマンドタグ](#コマンドタグ)を参照してください。
+
+**（警告）ベースのファイル形式が間違っている場合生成されたスタイルが壊れます。**
+
+### （1）ファイルを指定
+
+多言語で作成したい`*.base.md`ファイルを`mmg`コマンド引数（arguments）で入れてくれます。
+
+```sh
+mmg FileName.base.md
+```
+
+複数の引数は、間隔で区切ります。
+
+```sh
+mmg Foo.base.md Bar.base.md Baz.base.md
+```
+
+### （2）再帰オプション（recursive option）
+
+現在のディレクトリおよびサブディレクトリにあるすべてのデータベースファイルを変換したい場合は`--recursive`、または`-r`オプションを使用します。recursive optionはコマンドが入力された位置を基準にすべてのサブフォルダを移動します。まだ引数としてフォルダを指定することができません。
+
+```sh
+mmg --recursive
+```
+
+###（3）データベースファイルの検証
+
+問題があると疑われる場合。（通常は緑色で、異常は赤で表示されます。）
+
+```sh
+$ mmg -r --verbose
+----------------------
+ + .\README.base.md
+        [O] Tag count: {'en': 37, 'fr': 37, 'kr': 37}
+ + .\example\example.base.md
+        [X] 4 language(s) not translated.
+            Tag count: {'en-US': 4, 'fr-FR': 4, 'ko-KR': 5, 'ja-JP': 4, '<Unknown>': 1}
+        Line 28: This language reappeared before all languages appeared once.
+        Line 36: A common area appeared before all languages come out.
+        Line 57: Unknown suffix detected.
+        Line 59: This language reappeared before all languages appeared once.
+----------------------
+ => 2 base markdowns were found.
+Do you want to convert these files? [y/N]
+```
+
+問題がなければ、
+
+```sh
+$ mmg -r --verbose
+----------------------
+ + .\README.base.md
+        [O] Tag count: {'en': 37, 'fr': 37, 'kr': 37}
+ + .\example\example.base.md
+        [O] Tag count: {'en-US': 4, 'fr-FR': 4, 'ko-KR': 4, 'ja-JP': 4}
+----------------------
+ => 2 base markdowns were found.
+Do you want to convert these files? [y/N]
+```
+
+### （4）より多くの説明
+
+- 各フォルダの同じ場所で`{ファイル名}.{接尾辞}.md`になったファイルを見ることができます。例えば：
+  - 基本のとき：`{ファイル名}.en.md`、`{ファイル名}.kr.md`、`{ファイル名}.es.md`、...
+  - `en`サフィックス省略オプションのとき：`{ファイル名}.md`、`{ファイル名}.kr.md`、`{ファイル名}.es.md`、...
+- このジェネレータは、自動生成されたファイルを毎回上書きされるため、`{ファイル名}.base.md`ファイルを変更しても、毎回消去する必要がありません。ただ先ほどステップ2を再度実行します。
+
+## コマンドタグ
+
+### ヘッダ
+
+ヘッダは、必ず本体を開始する前に宣言する必要があります。
+
+1. **サフィックス宣言**
+
+    使用する言語を宣言します。次の例では、enとkrをキーワードで宣言しました。このキーワードは、接尾辞として使用されます。
+
+    ```markdown
+    <!-- multilingual suffix: en, kr, fr, es, jp, cn -->
+    ```
+
+1. **サフィックスを非表示**（必須ではない）
+
+    `no suffix`オプションは、ファイルを作成するときにサフィックスがつくのを防ぐことができます。言い換えればno suffixをenに設定すると、`ファイル名.en.md`ではなく、`ファイル名.md`が生成されます。**GitHub**からメイン`README`はサフィックスが付く認識にならないので、この機能が便利です。
+
+    ```markdown
+    <!-- no suffix: en -->
+    ```
+
+### バッジ付け
+
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-yellow.svg)](https://github.com/ryul1206/multilingual-markdown)
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-green.svg)](https://github.com/ryul1206/multilingual-markdown)
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-blue.svg)](https://github.com/ryul1206/multilingual-markdown)
+...
+
+```markdown
+[![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
+```
+
+### 本文
+
+パーサが下のタグ立ち寄る読む瞬間から、その後に読むすべてはメインテキストとして認識します。（だからヘッダをメインの前に書かなければならいます。）
+
+1. **キーワード**
+    1. 言語分類
+
+        言語を区別するタグは、`<!-- [キーワード] -->`同じ形で作成します。一つのキーワードが認識されると、他のキーワードが表示されるまで、そのキーワードとして認識されます。
+
+        ```markdown
+        <!-- [en] -->
+        <!-- [kr] -->
+        <!-- [fr] -->
+        <!-- [es] -->
+        <!-- [jp] -->
+        <!-- [cn] -->
+        ...
+        ```
+
+    1. 共通領域
+
+        生成されるすべてのファイルに共通に入る内容は`common`、キーワードを使用して作成します。
+
+        ```markdown
+        <!-- [common] -->
+        ```
+
+    1. 無視される領域
+
+        コメントやTODOなどのいくつかの項目は、生成されるファイルに含ましたくない場合があります。そのような場合`ignore`、キーワードを使用します。
+
+        ```markdown
+        <!-- [ignore] -->
+        ```
+
+1. **目次**
+
+    次のタグは、ジェネレータによって本文に自動的に置き換えられます。目次のレベルは、`level`部分を介してすることができます。最大のタイトル（`# 題目`）はhtmlで`<h1>`あるため`level 1`です。
+
+    **（注意）`#`に表示するマークダウンの見出しレベルをスキップエラーが発生します。つまり、`##`サブタイトルは`###`でなければします。**
+
+    ```markdown
+    <!-- [[ multilingual toc: level=2~3 ]] -->
+    ```
+
+    1. **`level`オプション**
+        - `level`を表記する方法は、合計4つあります。お客様のニーズに応じて、数字は変えたらされます。
+            - `level=2`：2レベルの見出しのみ目次にします。
+            - `level=2~`：2〜9レベルの見出しのみ目次にします。
+            - `level=~4`：1〜4レベルの見出しのみ目次にします。
+            - `level=2~4`：2〜4レベルの見出しのみ目次にします。
+        - 1つの記事で`table of contents`タグは何度も書くことができ、毎回異なる`level`オプションを与えることもできます。
+        - **注意💥**：もし`level`を省略すると、パーサが認識しない。
+        - **注意💥**：目次タグは、自動的に現在のキーワードを`common`変更します。だから目次タグも暗黙的に`common`に属します。
+    2. **`no-emoji`オプション**
+        - セクションのタイトルには、絵文字を入れながら、目次では、絵文字を消したいときがあります。😱 もしあなたがこのような状況であれば、以下のように`no-emoji`オプションを適用します。😎
+
+        ```markdown
+        <!-- [[ multilingual toc: level=2~3 no-emoji ]] -->
+        ```
+
+## 貢献
+
+翻訳、単純な改善、バグ情報提供などいかなるものでも大切に受けます。
+
+### 開発のためのlocalに構築する方法
+
+- Linux and MacOS
+  - Required packages: `pip3 install -r requirements_dev.txt --user`
+  - Install: `python3 setup.py install --user --record temp.txt`
+  - Usage: `mmg [OPTIONS] [FILENAMES]...`
+  - Uninstall: `xargs rm -rf < temp.txt`
+- Windows
+  - Required packages: `pip3 install -r .\requirements_dev.txt --user`
+  - Install: `python3 setup.py install --user --record temp.txt`
+  - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
+  - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
+
+### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)
+
+### Contributors
+
+> 貢献リストは英語のみで提供されます。
+
+- [@bkg2018 (Francis Piérot)](https://github.com/bkg2018): Added french translation to README and example. [PR #1](https://github.com/ryul1206/multilingual-markdown/pull/1)
+- [@mathben (Mathieu Benoit)](https://github.com/mathben): Update README pip installation with requirements.txt [PR #2](https://github.com/ryul1206/multilingual-markdown/pull/2)

--- a/README.kr.md
+++ b/README.kr.md
@@ -1,16 +1,17 @@
 # 다국어 마크다운 생성기
 
-이 패키지는 다국어 콘텐츠를 관리하고, 단일 기본 파일로부터 i18n 마크 다운을 생성하는 명령 줄 인터페이스(CLI)를 제공합니다.
+이 패키지는 단일 기본 파일로부터 다국어 콘텐츠를 관리하고, i18n 마크 다운을 생성하는 명령 줄 인터페이스 (CLI)를 제공합니다.
 
 [![Multilingual Markdown Generator](https://img.shields.io/badge/markdown-multilingual%20🌐-ff69b4.svg)](https://github.com/ryul1206/multilingual-markdown)
 ![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/ryul1206/multilingual-markdown.svg)
 ![GitHub](https://img.shields.io/github/license/ryul1206/multilingual-markdown.svg)
 [![CodeFactor](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/badge/master)](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/overview/master)
 
-🚀 **version 1.0-alpha.2** 🌏
+🚀 **version 1.0.1** 🌏
 [English](https://github.com/ryul1206/multilingual-markdown/blob/master/README.md),
 [Français](https://github.com/ryul1206/multilingual-markdown/blob/master/README.fr.md),
 [한국어](https://github.com/ryul1206/multilingual-markdown/blob/master/README.kr.md)
+[日本語](https://github.com/ryul1206/multilingual-markdown/blob/master/README.jp.md))
 
 ---
 
@@ -18,15 +19,16 @@
 
 1. [개요 ](#개요-)
     1. [작동 방식](#작동-방식)
-    1. [기능들](#기능들)
+    1. [기능](#기능)
 1. [설치](#설치)
 1. [업데이트](#업데이트)
 1. [제거](#제거)
 1. [사용법](#사용법)
-    1. [(1) 파일 지정](#(1)-파일-지정)
-    1. [(2) 재귀 옵션 (recursive option)](#(2)-재귀-옵션-(recursive-option))
-    1. [(3) 베이스 파일 유효성 검사](#(3)-베이스-파일-유효성-검사)
-    1. [(4) 부연 설명](#(4)-부연-설명)
+    1. [(0) 베이스 마크다운 파일 만들기](#0-베이스-마크다운-파일-만들기)
+    1. [(1) 파일 지정](#1-파일-지정)
+    1. [(2) 재귀 옵션 (recursive option)](#2-재귀-옵션-recursive-option)
+    1. [(3) 베이스 파일 유효성 검사](#3-베이스-파일-유효성-검사)
+    1. [(4) 부연 설명](#4-부연-설명)
 1. [명령어 태그](#명령어-태그)
     1. [헤더](#헤더)
     1. [뱃지 달기](#뱃지-달기)
@@ -41,11 +43,12 @@
 ### 작동 방식
 ![how it works](how-it-works.png)
 
-### 기능들
+### 기능
 
 - 파일 이름 뒤에 자동 접미사
-- 접미사 생략 옵션 (한 개 언어만 가능)
-- UTF-8 인코딩. 따라서 *아마도* 거의 모든 언어를 지원할겁니다. :) 🍷
+  - [IETF 언어 태그](https://ko.wikipedia.org/wiki/IETF_%EC%96%B8%EC%96%B4_%ED%83%9C%EA%B7%B8) 사용 가능
+  - 접미사 생략 옵션 (한 개 언어만 가능)
+- UTF-8 인코딩. 따라서 *아마* 거의 모든 언어를 지원합니다. :) 🍷
 - 자동 목차
     - 목차로 만들 제목수준 설정 가능
     - 목차에서 이모티콘 **표시/생략** 설정 가능
@@ -87,6 +90,8 @@ pip3 uninstall mmg
 ```
 
 ## 사용법
+
+### (0) 베이스 마크다운 파일 만들기
 
 `{파일이름}.base.md` 파일을 만듭니다. 예제는 [README.base.md](README.base.md) 와 [example.base.md](example/example.base.md) 를 참고하시고, 작성하는 규칙은 [명령어 태그](#명령어-태그)를 참고하십시오.
 
@@ -256,7 +261,7 @@ Do you want to convert these files? [y/N]
 
 ## 기여
 
-번역, 단순한 개선, 버그 제보 등 어떠한 것이라도 소중히 받습니다. 특히 이 `README.md` 문서를 여기에 없는 다른 언어로 번역해주신다면 매우 감사드립니다.
+번역, 단순한 개선, 버그 제보 등 어떠한 것이라도 소중히 받습니다.
 
 ### 개발을 위해 local로 빌드하는 방법
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -23,17 +23,17 @@
 1. [업데이트](#업데이트)
 1. [제거](#제거)
 1. [사용법](#사용법)
-    1. [(1) 파일 지정](#1-파일-지정)
-    1. [(2) 재귀 옵션 (recursive option)](#2-재귀-옵션-recursive-option)
-    1. [(3) 베이스 파일 유효성 검사](#3-베이스-파일-유효성-검사)
-    1. [(4) 부연 설명](#4-부연-설명)
+    1. [(1) 파일 지정](#(1)-파일-지정)
+    1. [(2) 재귀 옵션 (recursive option)](#(2)-재귀-옵션-(recursive-option))
+    1. [(3) 베이스 파일 유효성 검사](#(3)-베이스-파일-유효성-검사)
+    1. [(4) 부연 설명](#(4)-부연-설명)
 1. [명령어 태그](#명령어-태그)
     1. [헤더](#헤더)
     1. [뱃지 달기](#뱃지-달기)
     1. [본문](#본문)
 1. [기여](#기여)
     1. [개발을 위해 local로 빌드하는 방법](#개발을-위해-local로-빌드하는-방법)
-    1. [[Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)](#Changeloghttpsgithubcomryul1206multilingual-markdownblobmasterCHANGELOGmd)
+    1. [Changelog](#Changelog)
     1. [Contributors](#Contributors)
 
 ## 개요 🔎
@@ -265,11 +265,11 @@ Do you want to convert these files? [y/N]
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `mmg [OPTIONS] [FILENAMES]...`
   - Uninstall: `xargs rm -rf < temp.txt`
-- Windows (Not recommended)
+- Windows
   - Required packages: `pip3 install -r .\requirements_dev.txt --user`
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
-  - Uninstall (PowerShell): `Get-Content .\temp.txt | Remove-Item`
+  - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
 ### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
 

--- a/README.kr.md
+++ b/README.kr.md
@@ -271,7 +271,7 @@ Do you want to convert these files? [y/N]
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
   - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
-### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
+### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ This package provides a command-line interface to manage multilingual contents a
 ![GitHub](https://img.shields.io/github/license/ryul1206/multilingual-markdown.svg)
 [![CodeFactor](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/badge/master)](https://www.codefactor.io/repository/github/ryul1206/multilingual-markdown/overview/master)
 
-🚀 **version 1.0-alpha.2** 🌏
+🚀 **version 1.0.1** 🌏
 [English](https://github.com/ryul1206/multilingual-markdown/blob/master/README.md),
 [Français](https://github.com/ryul1206/multilingual-markdown/blob/master/README.fr.md),
 [한국어](https://github.com/ryul1206/multilingual-markdown/blob/master/README.kr.md)
+[日本語](https://github.com/ryul1206/multilingual-markdown/blob/master/README.jp.md))
 
 ---
 
@@ -23,10 +24,11 @@ This package provides a command-line interface to manage multilingual contents a
 1. [Update](#Update)
 1. [Uninstall](#Uninstall)
 1. [How to Use](#How-to-Use)
-    1. [(1) File Designation](#(1)-File-Designation)
-    1. [(2) Recursive Option](#(2)-Recursive-Option)
-    1. [(3) Base File Validation](#(3)-Base-File-Validation)
-    1. [(4) More explanations](#(4)-More-explanations)
+    1. [(0) Make a Base Markdown File](#0-Make-a-Base-Markdown-File)
+    1. [(1) File Designation](#1-File-Designation)
+    1. [(2) Recursive Option](#2-Recursive-Option)
+    1. [(3) Base File Validation](#3-Base-File-Validation)
+    1. [(4) More explanations](#4-More-explanations)
 1. [Command Tags](#Command-Tags)
     1. [Headers](#Headers)
     1. [Badges](#Badges)
@@ -44,8 +46,9 @@ This package provides a command-line interface to manage multilingual contents a
 ### Features
 
 - Auto suffix to file name
-- No suffix option (for one main language)
-- UTF-8 encoding. So *maybe* this will support almost all languages. :) 🍷
+  - [IETF language tags](https://en.wikipedia.org/wiki/IETF_language_tag) are also available.
+  - Remove suffix option for one main language
+- UTF-8 encoding. So this *would* support almost all languages. :) 🍷
 - Auto table of contents
     - Table of contents level options
     - Table of contents emoji **on-off** options
@@ -87,6 +90,8 @@ pip3 uninstall mmg
 ```
 
 ## How to Use
+
+### (0) Make a Base Markdown File
 
 Make `{something}.base.md` files. See [README.base.md](README.base.md) and [example.base.md](example/example.base.md) for examples, and [Command Tags](#Command-Tags) for rules.
 
@@ -256,7 +261,7 @@ Everything that the parser reads after the tag below is recognized as the main t
 
 ## Contribution
 
-I would appreciate anything you send. (e.g. translations, simple improvements, bug reports, and so on.) Especially I would be very grateful if you could translate this `README.md` document into your language not listed here and give it to me.
+I would appreciate anything you send. (e.g. translations, simple improvements, bug reports, and so on.)
 
 ### How to build locally for development
 

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ I would appreciate anything you send. (e.g. translations, simple improvements, b
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
   - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
-### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
+### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)
 
 ### Contributors
 

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ This package provides a command-line interface to manage multilingual contents a
 1. [Update](#Update)
 1. [Uninstall](#Uninstall)
 1. [How to Use](#How-to-Use)
-    1. [(1) File Designation](#1-File-Designation)
-    1. [(2) Recursive Option](#2-Recursive-Option)
-    1. [(3) Base File Validation](#3-Base-File-Validation)
-    1. [(4) More explanations](#4-More-explanations)
+    1. [(1) File Designation](#(1)-File-Designation)
+    1. [(2) Recursive Option](#(2)-Recursive-Option)
+    1. [(3) Base File Validation](#(3)-Base-File-Validation)
+    1. [(4) More explanations](#(4)-More-explanations)
 1. [Command Tags](#Command-Tags)
     1. [Headers](#Headers)
     1. [Badges](#Badges)
     1. [Main Text](#Main-Text)
 1. [Contribution](#Contribution)
     1. [How to build locally for development](#How-to-build-locally-for-development)
-    1. [[Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)](#Changeloghttpsgithubcomryul1206multilingual-markdownblobmasterCHANGELOGmd)
+    1. [Changelog](#Changelog)
     1. [Contributors](#Contributors)
 
 ## Overview 🔎
@@ -265,11 +265,11 @@ I would appreciate anything you send. (e.g. translations, simple improvements, b
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `mmg [OPTIONS] [FILENAMES]...`
   - Uninstall: `xargs rm -rf < temp.txt`
-- Windows (Not recommended)
+- Windows
   - Required packages: `pip3 install -r .\requirements_dev.txt --user`
   - Install: `python3 setup.py install --user --record temp.txt`
   - Usage: `python3 -m mmgcli [OPTIONS] [FILENAMES]...`
-  - Uninstall (PowerShell): `Get-Content .\temp.txt | Remove-Item`
+  - Uninstall (PowerShell): `python3 -m pip uninstall mmg`
 
 ### [Changelog](https://github.com/ryul1206/multilingual-markdown/blob/master/CHANGELOG.md)
 

--- a/mmgcli/__init__.py
+++ b/mmgcli/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "1.0.a2"
+__version__ = "1.0.1"
 
 from .cli import main

--- a/mmgcli/base_parser.py
+++ b/mmgcli/base_parser.py
@@ -118,13 +118,14 @@ class MultilingualDoc(object):
         max_tag = max(suffix_counter.values())
         missing = sum(1 if max_tag != x else 0 for x in suffix_counter.values())
 
+        icon = "❌" if missing else "✅"
         color = "bright_red" if missing else "bright_green"
         message = ""
         if verbosity > 0:
-            message = f"\t❌ {missing} language(s) not translated.\n\t    " if missing else "\t✅ "
-            message += f"Tag count: {str(suffix_counter)}"
+            message = f"    {missing} language(s) not translated.\n" if missing else ""
+            message += f"    Tag count: {str(suffix_counter)}"
             message += buffer
-        return message, color
+        return icon, message, color
 
     def run(self):
         # Main converting

--- a/mmgcli/cli.py
+++ b/mmgcli/cli.py
@@ -77,8 +77,8 @@ def load_files(filenames, recursive, check, verbosity):
 
     click.echo("----------------------")
     for base in base_files:
-        _msg, color = base.check_log(verbosity=verbosity) if check else ("", "white")
-        click.secho(f" + {base.full_name}", fg=color)
+        icon, _msg, color = base.check_log(verbosity=verbosity) if check else ("+", "", "white")
+        click.secho(f" {icon} {base.full_name}", fg=color)
         if _msg:
             click.echo(_msg)
     click.echo("----------------------")

--- a/mmgcli/single_gen.py
+++ b/mmgcli/single_gen.py
@@ -104,8 +104,7 @@ class CreateMonolangualDoc(object):
                 self.append_toc(head, result.end() - 1)
 
     def append_toc(self, head, level):
-        # if (self.prev_level + 1) == level:  # new child
-        if self.prev_level < level:  # new child
+        if (self.prev_level + 1) == level:  # new child
             pass
         elif self.prev_level == level:  # same level
             self.toc_stack = self.toc_stack[:-1]

--- a/mmgcli/single_gen.py
+++ b/mmgcli/single_gen.py
@@ -1,5 +1,6 @@
 import os.path
 import re
+
 # import emoji
 import click
 from collections import OrderedDict  # toc
@@ -18,14 +19,27 @@ def remove_emoji(text):
     return emoji_pattern.sub(r"", text)  # no emoji
 
 
+def remove_links(text):
+    # remove: html style
+    tag_begin = r"(<a href=)(.(?<!<))+>"
+    tag_end = r"<\/a>"
+    text = re.sub(tag_begin, "", re.sub(tag_end, "", text))
+    # remove: markdown style
+    mdurl_pattern = r"\[(?P<TEXT>((?!\]\(.*\]\().)*)\]\(((?!\).*\)).)*\)"
+    text = re.sub(mdurl_pattern, lambda m: m.group("TEXT"), text)
+    return text
+
+
 def create_toc(_dict, min_, max_, enable_emoji_header, _toc_str="", _level=1):
     for head, child in _dict.items():
         if (min_ <= _level) and (_level <= max_):
             # head
             if not enable_emoji_header:
                 head = remove_emoji(head)
+            # Fix the issue #4 (URL bug)
+            head = remove_links(head)
             # suburl
-            spc = r"[`~!@#$%\^&\*\(\)_=\+\|\[\]\{\}\\\\;:'\",./<>\?]+"
+            spc = r"[`~!@#$%\^&\*_=\+\|\{\}\\\\;:'\",./<>\?]+"
             suburl = re.sub(spc, "", head)
             suburl = remove_emoji(suburl)
             suburl = suburl.replace("  ", " ").replace(" ", "-")

--- a/mmgcli/single_gen.py
+++ b/mmgcli/single_gen.py
@@ -39,8 +39,8 @@ def create_toc(_dict, min_, max_, enable_emoji_header, _toc_str="", _level=1):
             # Fix the issue #4 (URL bug)
             head = remove_links(head)
             # suburl
-            spc = r"[`~!@#$%\^&\*_=\+\|\{\}\\\\;:'\",./<>\?]+"
-            suburl = re.sub(spc, "", head)
+            special_char = r"[`~!@#$%\^&\*\(\)_=\+\|\[\]\{\}\\\\;:'\",./<>\?]+"
+            suburl = re.sub(special_char, "", head)
             suburl = remove_emoji(suburl)
             suburl = suburl.replace("  ", " ").replace(" ", "-")
             # toc line

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import sys
+# import sys
 import codecs
 import os
 import re


### PR DESCRIPTION
- **Added** - Japanese README
- **Changed** - Move the checklog icon to the front.
- **Fixed** - Fix [#4](https://github.com/ryul1206/multilingual-markdown/issues/4): ToC contents are broken when a header(#) has a link.

[View more Changelog](https://github.com/ryul1206/multilingual-markdown/blob/develop/CHANGELOG.md)