### PR TITLE
Bug fix for `--yes` flag

### DIFF
--- a/mmgcli/__init__.py
+++ b/mmgcli/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from .cli import main

--- a/mmgcli/cli.py
+++ b/mmgcli/cli.py
@@ -124,8 +124,8 @@ def main(filenames, recursive, yes, check, verbose):
         base_count = len(base_files)
         is_plural = base_count > 1
 
+        _msg = "these files" if is_plural else "this file"
         if not yes:
-            _msg = "these files" if is_plural else "this file"
             if not query_yes_no("Do you want to convert these files?"):
                 exit()
 

--- a/mmgcli/cli.py
+++ b/mmgcli/cli.py
@@ -124,7 +124,7 @@ def main(filenames, recursive, yes, check, verbose):
         base_count = len(base_files)
         is_plural = base_count > 1
 
-        _msg = "these files" if is_plural else "this file"
+        _msg = "files have" if is_plural else "file has"
         if not yes:
             if not query_yes_no("Do you want to convert these files?"):
                 exit()
@@ -134,7 +134,7 @@ def main(filenames, recursive, yes, check, verbose):
             base.run()
         click.secho("----------------------", fg="cyan")
 
-        click.secho(f" => {base_count} base {_msg} converted.\n", fg="cyan")
+        click.secho(f" => {base_count} base {_msg} been converted.\n", fg="cyan")
     else:
         raise click.UsageError(
             "You have not entered anything. Do 'mmg Foo.base.md' or 'mmg --recursive'."


### PR DESCRIPTION
Problem:

```shell
$ mmg --version
Version 1.0.2
$ mmg -y -r
----------------------
 ✅ ./README.base.md
 ✅ ./example/example.base.md
----------------------
 => 2 base markdowns were found.
    Your verbosity is 0. Try the `--verbose` option for more details.
----------------------
./README.base.md
	en: ./README.md
	fr: ./README.fr.md
	kr: ./README.kr.md
	jp: ./README.jp.md
./example/example.base.md
	en-US: ./example/example.md
	fr-FR: ./example/example.fr-FR.md
	ko-KR: ./example/example.ko-KR.md
	ja-JP: ./example/example.ja-JP.md
----------------------
local variable '_msg' referenced before assignment
```

Fix: move `_msg` initialisation a little bit upper and bump version.